### PR TITLE
Removed dated Terminus version reference (small copy change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Terminus Plugin that allows for installation of Quicksilver webhooks from the Quicksilver examples, or a personal collection, on [Pantheon](https://www.pantheon.io) sites.
 
-Adds a command 'quicksilver' to Terminus 1.x which you can use to initialize a starting pantheon.yml file, or add a quicksilver web hook from the examples respository or a personal collection. For a version that works with Terminus 0.x, see the [0.x branch](https://github.com/pantheon-systems/terminus-secrets-plugin/tree/0.x).
+Adds a command 'quicksilver' to Terminus which you can use to initialize a starting pantheon.yml file, or add a quicksilver web hook from the examples respository or a personal collection. For a version that works with Terminus 0.x, see the [0.x branch](https://github.com/pantheon-systems/terminus-secrets-plugin/tree/0.x).
 
 Use as directed by Quicksilver examples.
 


### PR DESCRIPTION
Removed the version number in the intro copy since it's not needed anymore. Missed it last pass.