### PR TITLE
Fix installation issues with Terminus 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pantheon-systems/terminus-quicksilver-plugin",
+    "name": "lpeabody/terminus-quicksilver-plugin",
     "description": "A plugin for Terminus-CLI that allows for installation of Quicksilver webhooks from the Quicksilver examples, or a personal collection.",
     "homepage": "https://github.com/pantheon-systems/terminus-quicksilver-plugin",
     "license": "MIT",
@@ -9,10 +9,10 @@
     },
     "extra": {
         "terminus": {
-            "compatible-version": "^1.4|^2"
+            "compatible-version": "^3"
         }
     },
     "require": {
-        "consolidation/comments": "^1.0"
+        "consolidation/comments": "^1|^2"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lpeabody/terminus-quicksilver-plugin",
+    "name": "pantheon-systems/terminus-quicksilver-plugin",
     "description": "A plugin for Terminus-CLI that allows for installation of Quicksilver webhooks from the Quicksilver examples, or a personal collection.",
     "homepage": "https://github.com/pantheon-systems/terminus-quicksilver-plugin",
     "license": "MIT",
@@ -9,7 +9,7 @@
     },
     "extra": {
         "terminus": {
-            "compatible-version": "^3"
+            "compatible-version": "^1.4|^2|^3|^4"
         }
     },
     "require": {


### PR DESCRIPTION
# Changes

- Current dependency on `consolidation/comments:^1.0` prevents Terminus 4.x from installing this plugin. Update to be compatible with `consolidation/comments:^2`.

Fixes https://github.com/pantheon-systems/terminus-quicksilver-plugin/issues/25